### PR TITLE
Fix pylint consider-using-in warning

### DIFF
--- a/synology/api.py
+++ b/synology/api.py
@@ -101,7 +101,7 @@ class Api:
 
         # It appears that surveillance station needs lowercase text
         # true/false for the on switch
-        if state != HOME_MODE_ON and state != HOME_MODE_OFF:
+        if state not in (HOME_MODE_ON, HOME_MODE_OFF):
             raise ValueError('Invalid home mode state')
 
         api = self._api_info['home_mode']


### PR DESCRIPTION
The build seems to be failing after merging of #6 due to pylint warning:
`synology/api.py:104:11: R1714: Consider merging these comparisons with "in" to 'state not in (HOME_MODE_ON, HOME_MODE_OFF)' (consider-using-in)`